### PR TITLE
test: fixed test-unsetenv by patch to gnulib version of stdlib.h

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -5,28 +5,27 @@
 export ZOPEN_TYPE="TARBALL"
 
 export ZOPEN_TARBALL_URL="https://gnu.askapache.com/diffutils/diffutils-3.8.tar.xz"
-export ZOPEN_TARBALL_DEPS="curl xz make"
+export ZOPEN_TARBALL_DEPS="curl xz make zoslib"
 
 export ZOPEN_EXTRA_CFLAGS="-Wno-unused-const-variable -Wno-tautological-constant-out-of-range-compare -Wno-missing-prototypes -Wno-tautological-compare -Wno-implicit-function-declaration"
 export ZOPEN_BOOTSTRAP=skip
-
-# test-unsetenv hangs forever, skip tests until this is fixed.
-export ZOPEN_CHECK="skip"
-
-zopen_check_results()
-{
-  return 3 # non-functional
-}
 
 zopen_check_results()
 {
 chk="$2_check.log"
 
-failures=$(egrep '^# FAIL:|^# ERROR:|^# XFAIL' ${chk} | tail -1 | awk ' { print $3; }')
-totalTests=$(egrep '^# ERROR:|^# PASS:|^# XFAIL:|^# FAIL:|^# XPASS:' ${chk} | tail -1 | awk ' { print $3; }')
+ERROR=$(egrep '^# ERROR:' ${chk} | tail -1 | awk '{ print $3; }')
+SKIP=$(egrep '^# SKIP:' ${chk} | tail -1 | awk '{ print $3; }')
+PASS=$(egrep '^# PASS:' ${chk} | tail -1 | awk '{ print $3; }')
+FAIL=$(egrep '^# FAIL:' ${chk} | tail -1 | awk '{ print $3; }')
+XFAIL=$(egrep '^# XFAIL:' ${chk} | tail -1 | awk '{ print $3; }')
+TOTAL=$(egrep '^# TOTAL:' ${chk} | tail -1 | awk '{ print $3; }')
+
+totalTests=$(echo "${TOTAL}-${SKIP}" | bc )
+actualFailures=$(echo "${FAIL}+${XFAIL}+${ERROR}" | bc)
 
 cat <<ZZ
-actualFailures:$failures
+actualFailures:$actualFailures
 totalTests:$totalTests
 expectedFailures:0
 ZZ

--- a/patches/PR3/README
+++ b/patches/PR3/README
@@ -1,0 +1,1 @@
+The stdlib.h patch adds a remapping (via pragma) of the unsetenv runtime library function to the gnu version of stdlib.h in the same manner that our own xlclag version of stdlib.h does it.

--- a/patches/PR3/stdlib.in.h.patch
+++ b/patches/PR3/stdlib.in.h.patch
@@ -1,0 +1,25 @@
+diff --git a/lib/stdlib.in.h b/lib/stdlib.in.h
+index 652062d..c728caf 100644
+--- a/lib/stdlib.in.h
++++ b/lib/stdlib.in.h
+@@ -1401,6 +1401,20 @@ _GL_WARN_ON_USE (unlockpt, "unlockpt is not portable - "
+ #  endif
+ _GL_FUNCDECL_RPL (unsetenv, int, (const char *name) _GL_ARG_NONNULL ((1)));
+ _GL_CXXALIAS_RPL (unsetenv, int, (const char *name));
++#if defined(__MVS__)
++  #ifndef __EDC_LE
++    #define __EDC_LE 0x10000000
++  #endif
++  #if __TARGET_LIB__ >= __EDC_LE
++    #ifdef __SUSV3
++      #ifdef __NATIVE_ASCII_F
++        #pragma map(unsetenv,"\174\174A00471")
++      #else
++        #pragma map(unsetenv,"\174\174UNSTNV")
++      #endif
++    #endif
++  #endif
++#endif
+ # else
+ #  if !@HAVE_DECL_UNSETENV@
+ _GL_FUNCDECL_SYS (unsetenv, int, (const char *name) _GL_ARG_NONNULL ((1)));


### PR DESCRIPTION
This patch fixes the hanging test `test-unsetenv`.  Turns out the test gets compiled with some gnulib version of stdlib.h (which apparently is for maximum compatibility between platforms).  It so happens that our own version of stdlib.h (in /usr/include/stdlib.h) contains pragmas that, under certain conditions, remap the unsetenv runtime library external name to an 8 character MVS name, depending on the ascii setting.  The patch adds this logic to the gnulib version of stdlib.h (in `lib/stdlib.in.h`) and the test at least now fails rather than hangs forever.
Also, I fixed up the zopen_check_results() logic so that we're properly reporting the test status.